### PR TITLE
Add metadata for pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neural Data Simulator
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](.github/CODE_OF_CONDUCT.md)
 [![Linting](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/lint.yml/badge.svg)](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/lint.yml)
 [![Tests](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/test.yml/badge.svg)](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/test.yml)
 
@@ -28,7 +28,7 @@ brew install labstreaminglayer/tap/lsl
 Install the NDS package with the included examples and utilities via pip:
 
 ```
-pip install neural-data-simulator[extras]
+pip install "neural-data-simulator[extras]"
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Neural Data Simulator
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](.github/CODE_OF_CONDUCT.md)
 [![Linting](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/lint.yml/badge.svg)](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/lint.yml)
 [![Tests](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/test.yml/badge.svg)](https://github.com/agencyenterprise/neural-data-simulator/actions/workflows/test.yml)
 
@@ -40,6 +39,6 @@ nds_post_install_config
 run_closed_loop
 ```
 
-![quick-start](docs/source/images/quick-start.gif)
+![quick-start](https://github.com/agencyenterprise/neural-data-simulator/raw/main/docs/source/images/quick-start.gif)
 
 > **_NOTE:_** You might need to give permissions like network access when running the scripts.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Neural Data Simulator"
-copyright = "2023, AE Studio & Chad Boulay"
-author = "AE Studio & Chad Boulay"
-release = "0.1.0"
+copyright = "2023, AE Studio & Chadwick Boulay"
+author = "AE Studio & Chadwick Boulay"
+release = "0.1.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -10,7 +10,7 @@ The `neural-data-simulator` package contains:
 You can install `NDS`, with all included utilities and example implementations, using:
 
 ```
-pip install neural-data-simulator[extras]
+pip install "neural-data-simulator[extras]"
 ```
 
 ```{important}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neural-data-simulator"
-version = "0.1.0"
+version = "0.1.1"
 description = "Electrophysiology simulator data for developing Brain-Computer Interfaces"
 authors = ["AE Studio, Chadwick Boulay"]
 packages = [
@@ -10,6 +10,19 @@ packages = [
     {include = "tasks", from = "src"},
     {include = "plugins", from = "src"},
 ]
+readme = "README.md"
+license = "Apache-2.0"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/agencyenterprise/neural-data-simulator"
+"Documentation" = "https://agencyenterprise.github.io/neural-data-simulator/"
+"Bug Tracker" = "https://github.com/agencyenterprise/neural-data-simulator/issues"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "neural-data-simulator"
 version = "0.1.1"
 description = "Electrophysiology simulator data for developing Brain-Computer Interfaces"
-authors = ["AE Studio, Chadwick Boulay"]
+authors = ["AE Studio <bci@ae.studio>", "Chadwick Boulay <chadwick.boulay@gmail.com>"]
+maintainers = ["Chadwick Boulay <chadwick.boulay@gmail.com>", "AE Studio <bci@ae.studio>"]
 packages = [
     {include = "nds", from = "src"},
     {include = "decoder", from = "src"},

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -13,7 +13,7 @@ def run():
             "extras couldn't be imported"
         )
         print("Please reinstall neural-data-simulator with extras by running:")
-        print("pip install 'neural-data-simulator[extras]'")
+        print('pip install "neural-data-simulator[extras]"')
         return
 
     encoder = subprocess.Popen(["encoder"])


### PR DESCRIPTION
#### Changes

- Remove the broken link to `CODE_OF_CONDUCT`.
- Change the GIF url in the readme to be absolute in hope that it will render on pypi website.
- Add quotes around the package name with [extras] so that it can be copy-pasted in zsh shells as well. 
- Include the `README`, `license`, `classifiers` and `urls` for the `pypi` package distribution so that the rendered `PKG-INFO` is as follows:
```
Metadata-Version: 2.1
Name: neural-data-simulator
Version: 0.1.1
Summary: Electrophysiology simulator data for developing Brain-Computer Interfaces
License: Apache-2.0
Author: AE Studio, Chadwick Boulay
Requires-Python: >=3.9,<3.12
Classifier: License :: OSI Approved :: Apache Software License
Classifier: Operating System :: MacOS
Classifier: Operating System :: Microsoft :: Windows
Classifier: Operating System :: POSIX :: Linux
Classifier: Programming Language :: Python :: 3
Classifier: Programming Language :: Python :: 3.9
Classifier: Programming Language :: Python :: 3.10
Classifier: Programming Language :: Python :: 3.11
Provides-Extra: extras
Requires-Dist: colorednoise (>=2.1.0,<3.0.0)
Requires-Dist: joblib (>=1.2.0,<2.0.0) ; extra == "extras"
Requires-Dist: matplotlib (>=3.7.1,<4.0.0) ; extra == "extras"
Requires-Dist: neo (>=0.12.0,<0.13.0)
Requires-Dist: numpy (>=1.22.4,<2.0.0)
Requires-Dist: pooch (>=1.7.0,<2.0.0)
Requires-Dist: pyaml (>=21.10.1,<22.0.0)
Requires-Dist: pydantic (>=1.9.1,<2.0.0)
Requires-Dist: pydantic-yaml (>=0.9.0,<0.10.0)
Requires-Dist: pygame (==2.2.0.dev2) ; extra == "extras"
Requires-Dist: pylsl (>=1.16.1,<2.0.0)
Requires-Dist: pyobjc-framework-Quartz ; (sys_platform == "darwin") and (extra == "extras")
Requires-Dist: scikit-learn (==1.2.1) ; extra == "extras"
Requires-Dist: scipy (>=1.10.0,<2.0.0)
Requires-Dist: screeninfo (==0.8.1) ; extra == "extras"
Description-Content-Type: text/markdown

# Neural Data Simulator
... CONTENTS OF README ...
```