### PR TITLE
Update splash screen help text with the input device name

### DIFF
--- a/src/tasks/center_out_reach/input_events.py
+++ b/src/tasks/center_out_reach/input_events.py
@@ -26,6 +26,11 @@ class InputHandler:
         self.event_handlers = dict()
         self.joystick_input = JoystickInput()
 
+    @property
+    def input_device_name(self):
+        """Get the name of the input device."""
+        return "joystick" if self.joystick_input.joystick else "mouse"
+
     def set_handler_for_event(self, event: InputEvent, handler: Callable):
         """Set a function as a handler for a specific input event."""
         self.event_handlers[event] = handler

--- a/src/tasks/center_out_reach/task_runner.py
+++ b/src/tasks/center_out_reach/task_runner.py
@@ -109,13 +109,13 @@ class TaskRunner:
         """Signal the loop that it should stop."""
         self.should_stop_loop = True
 
-    def run(self, task_state: TaskState):
+    def run(self, task_state: TaskState, user_input: InputHandler):
         """Start the loop.
 
         Args:
             task_state: The state machine that should be updated by the loop.
+            user_input: The user input controller for actual cursor.
         """
-        user_input = InputHandler()
         task_window = task_state.task_window
 
         user_input.set_handler_for_event(InputEvent.EXIT, self.stop)


### PR DESCRIPTION
#### Introduction

Fixes https://github.com/agencyenterprise/neural-data-simulator/issues/10

Makes the splash screen (game menu) text display the name of the default cursor controller: mouse or joystick.

<img width="545" alt="Screenshot 2023-05-04 at 08 45 38" src="https://user-images.githubusercontent.com/13623704/236131542-1edab790-c85d-45c5-9d95-29efa1bd9b53.png">
<img width="564" alt="Screenshot 2023-05-04 at 08 44 46" src="https://user-images.githubusercontent.com/13623704/236131548-1b04c40c-f557-4541-a1b6-20eb2fe53e5f.png">

