### PR TITLE
Store log messages in memory until the logger is configured

### DIFF
--- a/src/decoder/run_decoder.py
+++ b/src/decoder/run_decoder.py
@@ -20,9 +20,11 @@ from neural_data_simulator.settings import LSLOutputModel
 from neural_data_simulator.settings import TimerModel
 from neural_data_simulator.util.runtime import configure_logger
 from neural_data_simulator.util.runtime import get_abs_path
+from neural_data_simulator.util.runtime import initialize_logger
 from neural_data_simulator.util.runtime import open_connection
 from neural_data_simulator.util.settings_loader import get_script_settings
 
+SCRIPT_NAME = "nds-decoder"
 logger = logging.getLogger(__name__)
 
 
@@ -114,6 +116,7 @@ def _setup_decoder(
 
 def run():
     """Run the decoder loop."""
+    initialize_logger(SCRIPT_NAME)
     parser = argparse.ArgumentParser(description="Run decoder.")
     parser.add_argument(
         "--settings-path",
@@ -127,7 +130,7 @@ def run():
             parser.parse_args().settings_path, "settings_decoder.yaml", _Settings
         ),
     )
-    configure_logger("nds-decoder", settings.log_level)
+    configure_logger(SCRIPT_NAME, settings.log_level)
 
     timer_settings = settings.timer
     timer = timing.get_timer(timer_settings.loop_time, timer_settings.max_cpu_buffer)

--- a/src/neural_data_simulator/scripts/run_encoder.py
+++ b/src/neural_data_simulator/scripts/run_encoder.py
@@ -36,9 +36,11 @@ from neural_data_simulator.settings import LSLOutputModel
 from neural_data_simulator.settings import Settings
 from neural_data_simulator.util.runtime import configure_logger
 from neural_data_simulator.util.runtime import get_abs_path
+from neural_data_simulator.util.runtime import initialize_logger
 from neural_data_simulator.util.runtime import unwrap
 from neural_data_simulator.util.settings_loader import get_script_settings
 
+SCRIPT_NAME = "nds-encoder"
 logger = logging.getLogger(__name__)
 
 
@@ -214,6 +216,7 @@ def _setup_LSL_output(
 
 def run():
     """Load the configuration and start the encoder."""
+    initialize_logger(SCRIPT_NAME)
     parser = argparse.ArgumentParser(description="Run encoder.")
     parser.add_argument(
         "--settings-path",
@@ -226,7 +229,7 @@ def run():
             parser.parse_args().settings_path, "settings.yaml", Settings
         ),
     )
-    configure_logger("nds-encoder", settings.log_level)
+    configure_logger(SCRIPT_NAME, settings.log_level)
 
     if settings.encoder.input.type == EncoderEndpointType.FILE:
         input_file = unwrap(settings.encoder.input.file)

--- a/src/neural_data_simulator/scripts/run_ephys_generator.py
+++ b/src/neural_data_simulator/scripts/run_ephys_generator.py
@@ -33,9 +33,11 @@ from neural_data_simulator.settings import EphysGeneratorEndpointType
 from neural_data_simulator.settings import EphysGeneratorSettings
 from neural_data_simulator.settings import Settings
 from neural_data_simulator.util.runtime import configure_logger
+from neural_data_simulator.util.runtime import initialize_logger
 from neural_data_simulator.util.runtime import unwrap
 from neural_data_simulator.util.settings_loader import get_script_settings
 
+SCRIPT_NAME = "nds-ephys-generator"
 logger = logging.getLogger(__name__)
 
 
@@ -144,6 +146,7 @@ def _set_random_seed(random_seed: Optional[int]):
 
 def run():
     """Load the configuration and start the ephys generator."""
+    initialize_logger(SCRIPT_NAME)
     parser = argparse.ArgumentParser(description="Run ephys generator.")
     parser.add_argument(
         "--settings-path",
@@ -157,7 +160,7 @@ def run():
         ),
     )
     _set_random_seed(settings.ephys_generator.random_seed)
-    configure_logger("nds-ephys-generator", settings.log_level)
+    configure_logger(SCRIPT_NAME, settings.log_level)
 
     if settings.ephys_generator.input.type == EphysGeneratorEndpointType.LSL:
         lsl_input_settings = unwrap(settings.ephys_generator.input.lsl)

--- a/src/neural_data_simulator/scripts/run_streamer.py
+++ b/src/neural_data_simulator/scripts/run_streamer.py
@@ -32,9 +32,11 @@ from neural_data_simulator.settings import LSLChannelFormatType
 from neural_data_simulator.settings import LSLOutputModel
 from neural_data_simulator.util.runtime import configure_logger
 from neural_data_simulator.util.runtime import get_abs_path
+from neural_data_simulator.util.runtime import initialize_logger
 from neural_data_simulator.util.runtime import unwrap
 from neural_data_simulator.util.settings_loader import get_script_settings
 
+SCRIPT_NAME = "nds-streamer"
 logger = logging.getLogger(__name__)
 
 
@@ -284,6 +286,7 @@ def _get_irregular_stream_config(
 
 def run():
     """Load the configuration and start the streamer."""
+    initialize_logger(SCRIPT_NAME)
     parser = argparse.ArgumentParser(description="Run streamer.")
     parser.add_argument(
         "--settings-path",
@@ -296,7 +299,7 @@ def run():
             parser.parse_args().settings_path, "settings_streamer.yaml", _Settings
         ),
     )
-    configure_logger("nds-streamer", settings.log_level)
+    configure_logger(SCRIPT_NAME, settings.log_level)
 
     if settings.streamer.input_type == StreamerInputType.NPZ.value:
         input_settings = unwrap(settings.streamer.npz).input

--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -25,10 +25,12 @@ from neural_data_simulator.settings import LogLevel
 from neural_data_simulator.settings import LSLInputModel
 from neural_data_simulator.settings import LSLOutputModel
 from neural_data_simulator.util.runtime import configure_logger
+from neural_data_simulator.util.runtime import initialize_logger
 from neural_data_simulator.util.runtime import open_connection
 from neural_data_simulator.util.runtime import unwrap
 from neural_data_simulator.util.settings_loader import get_script_settings
 
+SCRIPT_NAME = "nds-center-out-reach"
 logger = logging.getLogger(__name__)
 
 
@@ -249,6 +251,7 @@ def _metrics_enabled(settings: _Settings) -> bool:
 
 def run():
     """Run the center-out reach task GUI."""
+    initialize_logger(SCRIPT_NAME)
     parser = argparse.ArgumentParser(description="Run GUI.")
     parser.add_argument(
         "--settings-path",
@@ -264,7 +267,7 @@ def run():
             _Settings,
         ),
     )
-    configure_logger("nds-center-out-reach", settings.log_level)
+    configure_logger(SCRIPT_NAME, settings.log_level)
 
     if settings.center_out_reach.input.enabled:
         lsl_input_settings = unwrap(settings.center_out_reach.input.lsl)


### PR DESCRIPTION
Add an `initialize_logger` function that provisions an in-memory logger until the logger configuration is read from the settings. 