### PR TITLE
Adding docs redirector to CI

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -1,0 +1,19 @@
+name: Docs artifacts redirector
+on: [status]
+permissions: read-all
+jobs:
+  circleci_artifacts_redirector_job:
+    if: "${{ startsWith(github.event.context, 'ci/circleci: build_docs') }}"
+    permissions:
+      statuses: write
+    runs-on: ubuntu-20.04
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
+          artifact-path: 0/html/index.html
+          circleci-jobs: build_docs
+          job-title: Check the rendered docs here!


### PR DESCRIPTION
This PR adds the [larsoner/circleci-artifacts-redirector-action](https://github.com/larsoner/circleci-artifacts-redirector-action) github action to CI.
With this change the PRs should have a direct link to the built documentation 

**Note:** 
You will not be able to see the github action on this PR, it has to be merged to main first (check the [`Note`](https://github.com/larsoner/circleci-artifacts-redirector-action/blob/master/README.md?plain=1#L66))