### PR TITLE
Auto release based on PR label

### DIFF
--- a/.github/allowed_word_list.txt
+++ b/.github/allowed_word_list.txt
@@ -31,6 +31,7 @@ ephys
 Ephys
 filepath
 gamepad
+github
 highpass
 hstack
 int16
@@ -68,6 +69,7 @@ putatively
 pydantic
 pygame
 pylsl
+pypi
 pyplot
 readouterr
 reproducibility

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,11 @@
+#### Labels
+
+Assign one of these labels to the PR:
+- norelease
+- release:patch
+- release:minor
+- release:major
+
 #### Introduction
 
 In the introduction, please describe the type of change introduced by the pull request and its purpose and link the GitHub issue that this pull request addresses if possible, or add any reference that would provide more context to the reviewer.

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -1,0 +1,28 @@
+name: Pull Request release label enforcer
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    outputs:
+      status: ${{ steps.check-labels.outputs.status }}
+    steps:
+      - id: check-labels
+        uses: mheap/github-action-required-labels@v4
+        with:
+          mode: exactly
+          count: 1
+          labels: "release:patch, release:minor, release:major, norelease"
+          exit_type: success
+  do-other:
+    runs-on: ubuntu-latest
+    needs: label
+    steps:
+      - run: echo SUCCESS
+        if: needs.label.outputs.status == 'success'
+      - run: echo FAILURE && exit 1
+        if: needs.label.outputs.status == 'failure'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,14 +1,56 @@
-# Publish the python package when project is tagged in the v*.*.* form
-name: Python package
+name: Create a release
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
+  workflow_run:
+    workflows: [test, lint]
+    types:
+      - completed
+
 jobs:
-  build:
+  generate-release:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.TAG_CREATOR_API_TOKEN }}
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - id: release
+        uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: norelease
+          release_name: "NDS <RELEASE_TAG>"
+
+  push-release:
+    if: needs.generate-release.outputs.version != ''
+    runs-on: ubuntu-latest
+    needs: generate-release
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3.5.2
+        with:
+          ref: ${{ github.ref }}
+          token: ${{ secrets.TAG_CREATOR_API_TOKEN }}
+
+      - name: Setup python
+        uses: actions/setup-python@v4.6.1
+        with:
+          python-version: "3.10"
+
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+
+      - name: Update poetry version
+        run: |
+          poetry version ${{ needs.generate-release.outputs.version }}
+
+      - name: Commit poetry version
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Poetry version updated
+          file_pattern: pyproject.toml
+
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v1.16
         with:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -123,7 +123,7 @@ The release job will:
 1. generate a new package version using semantic versioning provided by [release on push](https://github.com/rymndhng/release-on-push-action/tree/master/)
 1. update the `pyproject.toml` version using `poetry`
 1. commit the updated `pyproject.toml` file using the [git-auto-commit action](https://github.com/stefanzweifel/git-auto-commit-action/tree/v4/)
-1. push the package to pypi using [poetry publish](JRubics/poetry-publish@v1.16)
+1. push the package to pypi using [poetry publish](https://github.com/JRubics/poetry-publish)
 1. build a new docker image and tag it with the previously generated semantic version
 
 Pull requests merged with the tag `norelease` will not trigger any of the actions listed above.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,6 +101,33 @@ By default, the encoder expects to consume an LSL stream, if you prefer to read 
 
 If you are already using your own virtual environment, you should not need to change anything.
 
+## Process
+
+### Versioning
+
+NDS uses [semantic versioning](https://en.wikipedia.org/wiki/Software_versioning#Semantic_versioning) to identify its releases.
+
+We use the [release on push](https://github.com/rymndhng/release-on-push-action/tree/master/) github action to generate the new version for each release. This github action generates the version based on a pull request label assigned before merge. The supported labels are:
+
+- `release-patch`
+- `release-minor`
+- `release-major`
+- `norelease`
+
+### Automatic release
+
+Merged pull requests with one of the labels `release-patch`, `release-minor` or `release-major` will trigger a release job on CI.
+
+The release job will:
+
+1. generate a new package version using semantic versioning provided by [release on push](https://github.com/rymndhng/release-on-push-action/tree/master/)
+1. update the `pyproject.toml` version using `poetry`
+1. commit the updated `pyproject.toml` file using the [git-auto-commit action](https://github.com/stefanzweifel/git-auto-commit-action/tree/v4/)
+1. push the package to pypi using [poetry publish](JRubics/poetry-publish@v1.16)
+1. build a new docker image and tag it with the previously generated semantic version
+
+Pull requests merged with the tag `norelease` will not trigger any of the actions listed above.
+
 ## Code requirements and conventions
 
 ```{note}


### PR DESCRIPTION
This PR enables an auto-release job based on the PR-assigned label.

The job should:
* bump the release version based on the PR label
* assign the new version to poetry
* commit the updated pyproject.toml file
* push the package with the new version to poetry