### PR TITLE
Handles argument passing to `run_closed_loop` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ htmldoc: apidoc
 	poetry run make -C docs html
 
 run-closed-loop:
-	poetry run encoder & poetry run ephys_generator & poetry run decoder & poetry run center_out_reach; pkill -f decoder; pkill -f ephys_generator; pkill -f encoder
+	poetry run run_closed_loop

--- a/docs/source/running_bci.md
+++ b/docs/source/running_bci.md
@@ -14,4 +14,9 @@ If you're eager to get started with NDS, you can run a full BCI simulation out o
 
 After running the `run_closed_loop` script[^1], you'll be prompted with instructions on how to perform the center-out reaching task. And that's it, you're now the `brain` that makes the `BCI`!
 
+You can specify different settings YAML for each module:
+ - `--ndv-settings-path` to specify where to find the settings file for the NDV modules (encoder and ephys_generator); 
+ - `--decoder-settings-path` to specify the settings file for the decoder module; and
+ - `--task-settings-path` for the task module (center_out_reach).
+
 [^1]: This script automates running the [`center_out_reach` task](tasks.md#provided-task) that is used to generate behavior data, the [encoder](encoder.md) to consume and generate spiking rates, the [ephys_generator](ephys_generator.md) to transform the spiking rates into electrophysiology data, and the [decoder](decoders.md) to transform electrophysiology data back into decoded behavior.

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -24,11 +24,10 @@ def _parse_args():
     return parser.parse_args()
 
 
-def _build_param_from_arg(args, arg_property, param_name):
+def _build_param_from_arg(arg_value, param_name):
     params = []
-    attr_value = getattr(args, arg_property, None)
-    if attr_value is not None:
-        params = [param_name, str(attr_value)]
+    if arg_value is not None:
+        params = [param_name, str(arg_value)]
     return params
 
 
@@ -50,11 +49,11 @@ def run():
 
     SETTINGS_PATH_PARAM = "--settings-path"
 
-    nds_params = _build_param_from_arg(args, "nds_settings_path", SETTINGS_PATH_PARAM)
+    nds_params = _build_param_from_arg(args.nds_settings_path, SETTINGS_PATH_PARAM)
     decoder_params = _build_param_from_arg(
-        args, "decoder_settings_path", SETTINGS_PATH_PARAM
+        args.decoder_settings_path, SETTINGS_PATH_PARAM
     )
-    task_params = _build_param_from_arg(args, "task_settings_path", SETTINGS_PATH_PARAM)
+    task_params = _build_param_from_arg(args.task_settings_path, SETTINGS_PATH_PARAM)
 
     encoder = subprocess.Popen(["encoder"] + nds_params)
     ephys = subprocess.Popen(["ephys_generator"] + nds_params)

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -1,5 +1,11 @@
 """Run all components of the BCI closed loop."""
 import subprocess
+import sys
+
+
+def start_process(command):
+    """Start a new process passing this current process arguments."""
+    return subprocess.Popen([command] + sys.argv[1:])
 
 
 def run():
@@ -16,10 +22,10 @@ def run():
         print('pip install "neural-data-simulator[extras]"')
         return
 
-    encoder = subprocess.Popen(["encoder"])
-    ephys = subprocess.Popen(["ephys_generator"])
-    decoder = subprocess.Popen(["decoder"])
-    center_out_reach = subprocess.Popen(["center_out_reach"])
+    encoder = start_process("encoder")
+    ephys = start_process("ephys_generator")
+    decoder = start_process("decoder")
+    center_out_reach = start_process("center_out_reach")
 
     center_out_reach.wait()
     encoder.kill()

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -1,7 +1,7 @@
 """Run all components of the BCI closed loop."""
-import subprocess
-from pathlib import Path
 import argparse
+from pathlib import Path
+import subprocess
 
 
 def _parse_args():
@@ -23,12 +23,14 @@ def _parse_args():
     )
     return parser.parse_args()
 
+
 def _build_param_from_arg(args, arg_property, param_name):
     params = []
     attr_value = getattr(args, arg_property, None)
     if attr_value is not None:
         params = [param_name, str(attr_value)]
     return params
+
 
 def run():
     """Start all components."""
@@ -43,19 +45,21 @@ def run():
         print("Please reinstall neural-data-simulator with extras by running:")
         print('pip install "neural-data-simulator[extras]"')
         return
-    
+
     args = _parse_args()
 
     SETTINGS_PATH_PARAM = "--settings-path"
 
     nds_params = _build_param_from_arg(args, "nds_settings_path", SETTINGS_PATH_PARAM)
-    decoder_params = _build_param_from_arg(args, "decoder_settings_path", SETTINGS_PATH_PARAM)
+    decoder_params = _build_param_from_arg(
+        args, "decoder_settings_path", SETTINGS_PATH_PARAM
+    )
     task_params = _build_param_from_arg(args, "task_settings_path", SETTINGS_PATH_PARAM)
 
-    encoder = subprocess.Popen(['encoder'] + nds_params)
-    ephys = subprocess.Popen(['ephys_generator'] + nds_params)
-    decoder = subprocess.Popen(['decoder'] + decoder_params)
-    center_out_reach = subprocess.Popen(['center_out_reach'] + task_params)
+    encoder = subprocess.Popen(["encoder"] + nds_params)
+    ephys = subprocess.Popen(["ephys_generator"] + nds_params)
+    decoder = subprocess.Popen(["decoder"] + decoder_params)
+    center_out_reach = subprocess.Popen(["center_out_reach"] + task_params)
 
     center_out_reach.wait()
     encoder.kill()


### PR DESCRIPTION
#### Introduction

Fixes argument passing to `run_closed_loop` script, so parameters like `--settings-path` can get passed through. 

#### Changes

This change sends all the arguments received on `run_closed_loop` script to the started modules subprocesses so they can be read and handled accordingly.

#### Behavior

The `--settings-path` parameter is being ignored on `run_closed_loop` script.  With this change, that parameter and any other parameter passed will be captured and handled.


