### PR TITLE
Fix window glitch

### DIFF
--- a/src/tasks/center_out_reach/metrics.py
+++ b/src/tasks/center_out_reach/metrics.py
@@ -6,6 +6,7 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 from numpy import ndarray
 import numpy as np
+import pygame
 from scipy import signal
 from sklearn.metrics import r2_score
 from tasks.center_out_reach.scalers import PixelsToMetersConverter
@@ -232,6 +233,7 @@ class MetricsCollector:
         Args:
             targets: List of target positions in pixels.
         """
+        pygame.display.init()
         h_lag = self._get_lag(
             self.actual_velocities[:, 0], self.decoded_velocities[:, 0]
         )

--- a/src/tasks/center_out_reach/task_runner.py
+++ b/src/tasks/center_out_reach/task_runner.py
@@ -170,3 +170,4 @@ class TaskRunner:
             # The rest of the time we use our precise timer to wait so that
             # we can output at exactly sample_rate with as little jitter as possible
             task_window.tick(self.sample_rate * 2)
+        task_window.stop_task()

--- a/src/tasks/center_out_reach/task_window.py
+++ b/src/tasks/center_out_reach/task_window.py
@@ -201,6 +201,15 @@ class TaskWindow:
         pygame.mouse.set_visible(False)
         pygame.event.set_grab(True)
 
+    def _release_and_show_cursor(self):
+        pygame.mouse.set_visible(True)
+        pygame.event.set_grab(False)
+
+    def stop_task(self):
+        """Stop the task."""
+        self._release_and_show_cursor()
+        pygame.display.quit()
+
     def _set_window_size_background_and_title(self) -> pygame.surface.Surface:
         screen = pygame.display.set_mode(self.window_size)
         screen.fill(self.params.background_color)


### PR DESCRIPTION
#### Introduction

Fixes a minor UI glitch that keeps the task window open, frozen, and still capturing the mouse when the experiment is already finished

#### Changes

Changes some mouse flags and manages the pygame display module so it can load/unload accordingly

#### Behavior

With the fix, at the end of the experiment, the task window is closed, the mouse is not get captured and the next window with the velocities overview is shown.