### PR TITLE
Fix local imports

### DIFF
--- a/src/neural_data_simulator/scripts/run_encoder.py
+++ b/src/neural_data_simulator/scripts/run_encoder.py
@@ -88,7 +88,7 @@ def _load_module(module_path: str, module_name: str) -> ModuleType:
     """Load an external module and return it."""
     module_path = get_abs_path(module_path)
     module_dir_path = Path(module_path).parent
-    sys.path.append(str(module_dir_path.parent.absolute()))
+    sys.path.append(str(module_dir_path.absolute()))
 
     loader = importlib.machinery.SourceFileLoader(module_name, module_path)
     spec = importlib.util.spec_from_loader(module_name, loader)


### PR DESCRIPTION
#### Introduction

Module local imports are failing, like importing a custom `local_util.py` on the same directory of the `model.py`

#### Changes

Minor fix on the sys.path update when running the module.

#### Behavior

Now it's possible to import local scripts under `model.py`, for example.
