### PR TITLE
Fix Subprocesses Cleanup on run_closed_loop

### DIFF
--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -364,7 +364,7 @@ def run():
     # This is used as a signal to a parent process that the main task has finished
     if args.pipe is not None:
         with open(args.pipe, "w") as pipe:
-            pipe.writelines(["main_task_finished"])
+            pipe.write("main_task_finished\n")
 
     if (
         not interrupted

--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -259,9 +259,9 @@ def run():
         help="Path to the settings_center_out_reach.yaml file.",
     )
     parser.add_argument(
-        "--pipe",
+        "--control-file",
         type=Path,
-        help="Path to the pipe file that will receive control messages.",
+        help="Path to the control file that will receive control messages.",
     )
     args = parser.parse_args()
     settings = cast(
@@ -362,9 +362,9 @@ def run():
         interrupted = True
 
     # This is used as a signal to a parent process that the main task has finished
-    if args.pipe is not None:
-        with open(args.pipe, "w") as pipe:
-            pipe.write("main_task_finished\n")
+    if args.control_file is not None:
+        with open(args.control_file, "w") as control_file:
+            control_file.write("main_task_finished\n")
 
     if (
         not interrupted

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -1,5 +1,45 @@
 """Run all components of the BCI closed loop."""
+import logging
+import os
 import subprocess
+import tempfile
+
+from neural_data_simulator.settings import LogLevel
+from neural_data_simulator.util.runtime import configure_logger
+from neural_data_simulator.util.runtime import initialize_logger
+
+SCRIPT_NAME = "nds-run-closed-loop"
+logger = logging.getLogger(__name__)
+
+
+def _terminate_process(label: str, popen_process: subprocess.Popen, timeout: int = 5):
+    logger.info(f"Terminating {label}")
+    popen_process.terminate()
+    try:
+        popen_process.wait(timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning(f"{label} did not terminate in time. Killing it")
+        popen_process.kill()
+
+
+def _create_pipe_file(pipe_name: str):
+    temp_dir = tempfile.mkdtemp()
+    pipe_path = os.path.join(temp_dir, pipe_name)
+    os.mkfifo(pipe_path)
+    return (temp_dir, pipe_path)
+
+
+def _wait_for_main_task_finish(pipe_path: str):
+    try:
+        with open(pipe_path, "r") as center_out_reach_pipe:
+            for line in center_out_reach_pipe:
+                if "main_task_finished" in line:
+                    logger.info("Main task finished")
+                    break
+    except KeyboardInterrupt:
+        logger.info("CTRL+C received. Exiting...")
+        return False
+    return True
 
 
 def run():
@@ -16,15 +56,33 @@ def run():
         print('pip install "neural-data-simulator[extras]"')
         return
 
+    initialize_logger(SCRIPT_NAME)
+    configure_logger(SCRIPT_NAME, LogLevel._INFO)
+
+    logger.info("Starting modules")
     encoder = subprocess.Popen(["encoder"])
     ephys = subprocess.Popen(["ephys_generator"])
     decoder = subprocess.Popen(["decoder"])
-    center_out_reach = subprocess.Popen(["center_out_reach"])
 
-    center_out_reach.wait()
-    encoder.kill()
-    ephys.kill()
-    decoder.kill()
+    temp_dir, center_out_reach_pipe_path = _create_pipe_file("center_out_reach")
+    center_out_reach = subprocess.Popen(
+        ["center_out_reach", "--pipe", center_out_reach_pipe_path]
+    )
+    logger.info("Modules started")
+
+    main_task_finished = _wait_for_main_task_finish(center_out_reach_pipe_path)
+    _terminate_process("encoder", encoder)
+    _terminate_process("ephys_generator", ephys)
+    _terminate_process("decoder", decoder)
+    if not main_task_finished:
+        _terminate_process("center_out_reach", center_out_reach)
+    else:
+        logger.info("Waiting for center_out_reach")
+        center_out_reach.wait()
+
+    os.remove(center_out_reach_pipe_path)
+    os.rmdir(temp_dir)
+    logger.info("Done")
 
 
 if __name__ == "__main__":

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -22,7 +22,7 @@ def _terminate_process(label: str, popen_process: subprocess.Popen, timeout: int
         popen_process.kill()
 
 
-def _create_pipe_file(pipe_name: str):
+def _create_pipe_file(pipe_name: str) -> tuple[str, str]:
     temp_dir = tempfile.mkdtemp()
     pipe_path = os.path.join(temp_dir, pipe_name)
     os.mkfifo(pipe_path)

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -33,15 +33,17 @@ def _create_pipe_file(pipe_name: str) -> tuple[str, str]:
 
 
 def _wait_for_pipe_message(pipe_path: str, pipe_message: str) -> bool:
-    """
-    Wait for the specified pipe_message in the specified pipe_path file.
-    Returns True if the message was found, False if the process was interrupted.
+    """Wait for a pipe message in a pipe file.
+
+    :param pipe_path: Path to the pipe file.
+    :param pipe_message:  Message to wait for.
+    :returns: True if the message was found, False if the process was interrupted.
     """
     try:
         with open(pipe_path, "r") as center_out_reach_pipe:
             for line in center_out_reach_pipe:
                 if pipe_message in line:
-                    logger.info("Main task finished")
+                    logger.info(f"Message {pipe_message} received")
                     break
     except KeyboardInterrupt:
         logger.info("CTRL+C received. Exiting...")

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -13,7 +13,7 @@ SCRIPT_NAME = "nds-run-closed-loop"
 logger = logging.getLogger(__name__)
 
 # This is the pipe message indicating that the main task has finished
-MAIN_TASK_FINISHED_PIPE_MSG = "main_task_finished"
+MAIN_TASK_FINISHED_MSG = "main_task_finished"
 
 
 def _terminate_process(label: str, popen_process: subprocess.Popen, timeout: int = 5):
@@ -62,7 +62,7 @@ def run():
             with open(control_file_path, "r") as file:
                 while True:
                     line = file.readline()
-                    if MAIN_TASK_FINISHED_PIPE_MSG in line:
+                    if MAIN_TASK_FINISHED_MSG in line:
                         logger.info("Main task finished")
                         break
                     if center_out_reach.poll() is not None:

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -89,8 +89,7 @@ def run():
 
     with tempfile.TemporaryDirectory() as temp_dir:
         control_file_path = os.path.join(temp_dir, "center_out_reach_control_file")
-        open(control_file_path, "x")
-
+        Path(control_file_path).touch(exist_ok=False)
         center_out_reach = subprocess.Popen(
             ["center_out_reach", "--control-file", control_file_path] + task_params
         )

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -66,7 +66,7 @@ def run():
                         logger.info("Main task finished")
                         break
                     if center_out_reach.poll() is not None:
-                        logger.info(f"Main task stopped unexpectedly.")
+                        logger.info("Main task stopped unexpectedly.")
                         break
                     time.sleep(0.5)
         except KeyboardInterrupt:

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -35,9 +35,12 @@ def _create_pipe_file(pipe_name: str) -> tuple[str, str]:
 def _wait_for_pipe_message(pipe_path: str, pipe_message: str) -> bool:
     """Wait for a pipe message in a pipe file.
 
-    :param pipe_path: Path to the pipe file.
-    :param pipe_message:  Message to wait for.
-    :returns: True if the message was found, False if the process was interrupted.
+    Args:
+        pipe_path: Path to the pipe file.
+        pipe_message:  Message to wait for.
+
+    Returns:
+        True if the message was found, False if the process was interrupted.
     """
     try:
         with open(pipe_path, "r") as center_out_reach_pipe:


### PR DESCRIPTION
#### Introduction

Abrupt termination of `run_closed_loop` with Ctrl+C can leave LSL streams undeleted and processes running in the background. Also, when the `center_out_reach` script terminates the main experiment task, the streams are still running while the metrics window "Velocities overview" is showing.
 
#### Changes

- Adds better error handling on KeyboardInterrupt scenarios, so Ctrl+C, is captured correctly.
- Adds subprocesses communication via pipes between `run_closed_loop` and `center_out_reach` to signal the end of the main task, so the `run_closed_loop` script can finalize the other running subprocesses.
- Better subprocesses termination: sends a SIGTERM, waits for 5s, and then a SIGKILL if the subprocesses didn't finish yet. Currently, it is just sending a SIGKILL without giving the subprocess a chance to quit.

#### Behavior

On `run_closed_loop`:
- Ctrl+C releases all created LSL streams, finishing in a clean state.
- Hitting "escape" or when the experiment is finished, all streams are cleared out.