### PR TITLE
Fix for run_closed_loop on Windows

### DIFF
--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -22,6 +22,7 @@ MAIN_TASK_FINISHED_MSG = "main_task_finished"
 def _run_process(args) -> subprocess.Popen:
     return subprocess.Popen(args, shell=sys.platform == "win32")
 
+
 def _terminate_process(label: str, popen_process: subprocess.Popen, timeout: int = 5):
     logger.info(f"Terminating {label}")
     popen_process.terminate()
@@ -30,6 +31,7 @@ def _terminate_process(label: str, popen_process: subprocess.Popen, timeout: int
     except (subprocess.TimeoutExpired, KeyboardInterrupt):
         logger.warning(f"{label} did not terminate in time. Killing it")
         popen_process.kill()
+
 
 def _parse_args():
     parser = argparse.ArgumentParser(description="Run closed loop.")

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -16,10 +16,10 @@ def run():
         print('pip install "neural-data-simulator[extras]"')
         return
 
-    encoder = subprocess.Popen(["encoder"])
-    ephys = subprocess.Popen(["ephys_generator"])
-    decoder = subprocess.Popen(["decoder"])
-    center_out_reach = subprocess.Popen(["center_out_reach"])
+    encoder = subprocess.Popen(["encoder"], shell=True)
+    ephys = subprocess.Popen(["ephys_generator"], shell=True)
+    decoder = subprocess.Popen(["decoder"], shell=True)
+    center_out_reach = subprocess.Popen(["center_out_reach"], shell=True)
 
     center_out_reach.wait()
     encoder.kill()

--- a/src/tasks/run_closed_loop.py
+++ b/src/tasks/run_closed_loop.py
@@ -1,5 +1,10 @@
 """Run all components of the BCI closed loop."""
 import subprocess
+import sys
+
+
+def _run_process(args) -> subprocess.Popen:
+    return subprocess.Popen(args, shell=sys.platform == "win32")
 
 
 def run():
@@ -16,10 +21,10 @@ def run():
         print('pip install "neural-data-simulator[extras]"')
         return
 
-    encoder = subprocess.Popen(["encoder"], shell=True)
-    ephys = subprocess.Popen(["ephys_generator"], shell=True)
-    decoder = subprocess.Popen(["decoder"], shell=True)
-    center_out_reach = subprocess.Popen(["center_out_reach"], shell=True)
+    encoder = _run_process(["encoder"])
+    ephys = _run_process(["ephys_generator"])
+    decoder = _run_process(["decoder"])
+    center_out_reach = _run_process(["center_out_reach"])
 
     center_out_reach.wait()
     encoder.kill()


### PR DESCRIPTION
#### Introduction

Running `run_closed_loop` with poetry on Windows without the extras package installed fails.

#### Changes

Adds the `shell=True` parameter so Windows can use the PATH to locate and run the scripts in poetry virtualenv. Also, as the scripts use the [shebang](https://pt.wikipedia.org/wiki/Shebang) they need the cmd shell on Windows to run properly.

#### Behavior

Now it's possible to run `run_closed_loop` on Windows with or without installing the extras and using your local environment.

