### PR TITLE
Fix CircularDeque append check

### DIFF
--- a/src/neural_data_simulator/util/circular_dequeue.py
+++ b/src/neural_data_simulator/util/circular_dequeue.py
@@ -14,7 +14,7 @@ class CircularDeque:
 
     def append(self, value) -> None:
         """Append a value to the deque."""
-        if len(self.deque) > self.num_elements:
+        if len(self.deque) >= self.num_elements:
             self.deque.popleft()
         self.deque.append(value)
 


### PR DESCRIPTION
#### Introduction

The CircularDeque is holding an additional element, which exceeds the intended number of elements it should contain. This issue causes the is_full method to incorrectly return False even when the deque is already full.

#### Changes

Fixes the number of elements condition.

#### Behavior

The fix ensures that the CircularDeque accurately maintains the intended number of elements and correctly reports if it is full or not.