### PR TITLE
Move script settings into their own modules

### DIFF
--- a/src/decoder/run_decoder.py
+++ b/src/decoder/run_decoder.py
@@ -7,6 +7,7 @@ from typing import cast
 
 from decoder.decoders import Decoder
 from decoder.decoders import PersistedFileDecoderModel
+from decoder.settings import DecoderSettings
 from pydantic_yaml import VersionedYamlModel
 
 from neural_data_simulator import inputs
@@ -29,7 +30,7 @@ class _Settings(VersionedYamlModel):
     """Decoder app settings."""
 
     log_level: LogLevel
-    decoder: Decoder
+    decoder: DecoderSettings
     timer: TimerModel
 
 
@@ -49,7 +50,7 @@ def _setup_LSL_input(stream_name: str, connection_timeout: float) -> inputs.LSLI
 
 
 def _setup_LSL_output(
-    output_settings: _Settings.Decoder.Output,
+    output_settings: DecoderSettings.Output,
 ) -> outputs.LSLOutputDevice:
     """Prepare output that will make the data available via an LSL stream.
 

--- a/src/decoder/run_decoder.py
+++ b/src/decoder/run_decoder.py
@@ -91,20 +91,26 @@ def _setup_decoder(
     return decoder
 
 
-def run():
-    """Run the decoder loop."""
-    initialize_logger(SCRIPT_NAME)
+def _parse_args_settings_path() -> Path:
+    """Parse command-line arguments for the settings path."""
     parser = argparse.ArgumentParser(description="Run decoder.")
     parser.add_argument(
         "--settings-path",
         type=Path,
         help="Path to the settings_decoder.yaml file.",
     )
+    args = parser.parse_args()
+    return args.settings_path
+
+
+def run():
+    """Run the decoder loop."""
+    initialize_logger(SCRIPT_NAME)
 
     settings = cast(
         _Settings,
         get_script_settings(
-            parser.parse_args().settings_path, "settings_decoder.yaml", _Settings
+            _parse_args_settings_path(), "settings_decoder.yaml", _Settings
         ),
     )
     configure_logger(SCRIPT_NAME, settings.log_level)

--- a/src/decoder/run_decoder.py
+++ b/src/decoder/run_decoder.py
@@ -7,7 +7,6 @@ from typing import cast
 
 from decoder.decoders import Decoder
 from decoder.decoders import PersistedFileDecoderModel
-from pydantic import BaseModel
 from pydantic_yaml import VersionedYamlModel
 
 from neural_data_simulator import inputs
@@ -15,8 +14,6 @@ from neural_data_simulator import outputs
 from neural_data_simulator import timing
 from neural_data_simulator.outputs import StreamConfig
 from neural_data_simulator.settings import LogLevel
-from neural_data_simulator.settings import LSLInputModel
-from neural_data_simulator.settings import LSLOutputModel
 from neural_data_simulator.settings import TimerModel
 from neural_data_simulator.util.runtime import configure_logger
 from neural_data_simulator.util.runtime import get_abs_path
@@ -29,27 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class _Settings(VersionedYamlModel):
-    """Decoder settings."""
-
-    class Decoder(BaseModel):
-        """Decoder settings."""
-
-        class Input(BaseModel):
-            """Decoder input settings."""
-
-            lsl: LSLInputModel
-
-        class Output(BaseModel):
-            """Decoder output settings."""
-
-            sampling_rate: float
-            n_channels: int
-            lsl: LSLOutputModel
-
-        input: Input
-        output: Output
-        model_file: str
-        spike_threshold: float
+    """Decoder app settings."""
 
     log_level: LogLevel
     decoder: Decoder

--- a/src/decoder/settings.py
+++ b/src/decoder/settings.py
@@ -6,7 +6,7 @@ from neural_data_simulator.settings import LSLInputModel
 from neural_data_simulator.settings import LSLOutputModel
 
 
-class Decoder(BaseModel):
+class DecoderSettings(BaseModel):
     """Decoder settings."""
 
     class Input(BaseModel):

--- a/src/decoder/settings.py
+++ b/src/decoder/settings.py
@@ -1,4 +1,4 @@
-"""Schema for Decoder settings."""""
+"""Schema for Decoder settings."""
 
 from pydantic import BaseModel
 

--- a/src/decoder/settings.py
+++ b/src/decoder/settings.py
@@ -1,0 +1,27 @@
+"""Schema for Decoder settings."""""
+
+from pydantic import BaseModel
+
+from neural_data_simulator.settings import LSLInputModel
+from neural_data_simulator.settings import LSLOutputModel
+
+
+class Decoder(BaseModel):
+    """Decoder settings."""
+
+    class Input(BaseModel):
+        """Decoder input settings."""
+
+        lsl: LSLInputModel
+
+    class Output(BaseModel):
+        """Decoder output settings."""
+
+        sampling_rate: float
+        n_channels: int
+        lsl: LSLOutputModel
+
+    input: Input
+    output: Output
+    model_file: str
+    spike_threshold: float

--- a/src/tasks/center_out_reach/settings.py
+++ b/src/tasks/center_out_reach/settings.py
@@ -1,0 +1,76 @@
+"""Settings schema for the center-out reach task."""
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import validator
+
+from neural_data_simulator.settings import LSLInputModel
+from neural_data_simulator.settings import LSLOutputModel
+
+
+class CenterOutReach(BaseModel):
+    """Center-out reach settings."""
+
+    class Input(BaseModel):
+        """Input settings."""
+
+        enabled: bool
+        lsl: Optional[LSLInputModel]
+
+        @validator("lsl")
+        def _lsl_config_is_set_for_input_enabled(cls, v, values):
+            if not v and values.get("enabled"):
+                raise ValueError("lsl needs to be configured when input is enabled")
+
+            return v
+
+    class Output(BaseModel):
+        """Output settings."""
+
+        lsl: LSLOutputModel
+
+    class Window(BaseModel):
+        """Window settings."""
+
+        class Colors(BaseModel):
+            """Colors used in the GUI."""
+
+            background: str
+            decoded_cursor: str
+            actual_cursor: str
+            target: str
+            target_waiting_for_cue: str
+            decoded_cursor_on_target: str
+
+        width: Optional[float]
+        height: Optional[float]
+        ppi: Optional[float]
+
+        colors: Colors
+
+    class StandardScaler(BaseModel):
+        """Velocity scaler settings."""
+
+        scale: list[float]
+        mean: list[float]
+
+    class Task(BaseModel):
+        """Task settings."""
+
+        target_radius: float
+        cursor_radius: float
+        radius_to_target: float
+        number_of_targets: int
+
+        delay_to_begin: float
+        delay_waiting_for_cue: float
+        target_holding_time: float
+        max_trial_time: int
+
+    input: Input
+    output: Output
+    sampling_rate: float
+    window: Window
+    with_metrics: bool
+    standard_scaler: StandardScaler
+    task: Task

--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -3,12 +3,11 @@ import argparse
 import logging
 from pathlib import Path
 import re
-from typing import cast, Optional, Tuple
+from typing import cast, Tuple
 
 import numpy as np
-from pydantic import BaseModel
-from pydantic import validator
 from pydantic_yaml import VersionedYamlModel
+from tasks.center_out_reach.settings import CenterOutReach
 from tasks.center_out_reach.input_events import InputHandler
 from tasks.center_out_reach.metrics import MetricsCollector
 from tasks.center_out_reach.scalers import PixelsToMetersConverter
@@ -22,8 +21,6 @@ from neural_data_simulator import inputs
 from neural_data_simulator import outputs
 from neural_data_simulator.outputs import StreamConfig
 from neural_data_simulator.settings import LogLevel
-from neural_data_simulator.settings import LSLInputModel
-from neural_data_simulator.settings import LSLOutputModel
 from neural_data_simulator.util.runtime import configure_logger
 from neural_data_simulator.util.runtime import initialize_logger
 from neural_data_simulator.util.runtime import open_connection
@@ -35,74 +32,10 @@ logger = logging.getLogger(__name__)
 
 
 class _Settings(VersionedYamlModel):
-    """Center-out reach settings."""
+    """Center-out reach app settings.
 
-    class CenterOutReach(BaseModel):
-        """Center-out reach settings."""
-
-        class Input(BaseModel):
-            """Input settings."""
-
-            enabled: bool
-            lsl: Optional[LSLInputModel]
-
-            @validator("lsl")
-            def _lsl_config_is_set_for_input_enabled(cls, v, values):
-                if not v and values.get("enabled"):
-                    raise ValueError("lsl needs to be configured when input is enabled")
-
-                return v
-
-        class Output(BaseModel):
-            """Output settings."""
-
-            lsl: LSLOutputModel
-
-        class Window(BaseModel):
-            """Window settings."""
-
-            class Colors(BaseModel):
-                """Colors used in the GUI."""
-
-                background: str
-                decoded_cursor: str
-                actual_cursor: str
-                target: str
-                target_waiting_for_cue: str
-                decoded_cursor_on_target: str
-
-            width: Optional[float]
-            height: Optional[float]
-            ppi: Optional[float]
-
-            colors: Colors
-
-        class StandardScaler(BaseModel):
-            """Velocity scaler settings."""
-
-            scale: list[float]
-            mean: list[float]
-
-        class Task(BaseModel):
-            """Task settings."""
-
-            target_radius: float
-            cursor_radius: float
-            radius_to_target: float
-            number_of_targets: int
-
-            delay_to_begin: float
-            delay_waiting_for_cue: float
-            target_holding_time: float
-            max_trial_time: int
-
-        input: Input
-        output: Output
-        sampling_rate: float
-        window: Window
-        with_metrics: bool
-        standard_scaler: StandardScaler
-        task: Task
+    Defines the schema of a `settings_center_out_reach.yaml` file.
+    """
 
     log_level: LogLevel
     center_out_reach: CenterOutReach
@@ -269,7 +202,7 @@ def run():
         get_script_settings(
             args.settings_path,
             "settings_center_out_reach.yaml",
-            _Settings,
+            settings_parser=_Settings,
         ),
     )
     configure_logger(SCRIPT_NAME, settings.log_level)

--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -7,11 +7,11 @@ from typing import cast, Tuple
 
 import numpy as np
 from pydantic_yaml import VersionedYamlModel
-from tasks.center_out_reach.settings import CenterOutReach
 from tasks.center_out_reach.input_events import InputHandler
 from tasks.center_out_reach.metrics import MetricsCollector
 from tasks.center_out_reach.scalers import PixelsToMetersConverter
 from tasks.center_out_reach.scalers import StandardVelocityScaler
+from tasks.center_out_reach.settings import CenterOutReach
 from tasks.center_out_reach.task_runner import TaskRunner
 from tasks.center_out_reach.task_state import StateParams
 from tasks.center_out_reach.task_state import TaskState

--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -70,8 +70,8 @@ def _setup_LSL_output(config: StreamConfig) -> outputs.LSLOutputDevice:
 
 
 def _get_task_window_params(
-    task_settings: _Settings.CenterOutReach.Task,
-    window_settings: _Settings.CenterOutReach.Window,
+    task_settings: CenterOutReach.Task,
+    window_settings: CenterOutReach.Window,
     unit_converter: PixelsToMetersConverter,
 ):
     return TaskWindow.Params(

--- a/src/tasks/run_center_out_reach.py
+++ b/src/tasks/run_center_out_reach.py
@@ -182,9 +182,8 @@ def _metrics_enabled(settings: _Settings) -> bool:
     )
 
 
-def run():
-    """Run the center-out reach task GUI."""
-    initialize_logger(SCRIPT_NAME)
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run GUI.")
     parser.add_argument(
         "--settings-path",
@@ -197,6 +196,13 @@ def run():
         help="Path to the control file that will receive control messages.",
     )
     args = parser.parse_args()
+    return args
+
+
+def run():
+    """Run the center-out reach task GUI."""
+    initialize_logger(SCRIPT_NAME)
+    args = _parse_args()
     settings = cast(
         _Settings,
         get_script_settings(


### PR DESCRIPTION
https://github.com/agencyenterprise/neural-data-simulator/issues/30

#### Introduction

User feedback: make it easier to mix and match components, e.g. the run-script should be more light-weight. A non-literal example:

```python
def run():
   settings = CLI().parse_settings(CenterOut)
   task =  CenterOut(encoder=Encoder(), decoder=Decoder(), **settings)
   task.execute()
```


#### Changes

The first step of this is to move the module settings into their files, so that other files can import and build on them. Note: App/script-specific settings are kept in the app/script.

In a future PR, we will also move the streamer script into its own folder & settings module.

#### Behavior

Code behavior should be the same.
Testing: ran `run_closed_loop` locally, and ran unit tests.

#####
A timing test sometimes fails for me:

```python
    def test_wait_jitter(self, timer):
        """Test that the jitter produced is less than 1ms.

        To prevent the test from failing you must choose an appropriate
        max_cpu_buffer_ns value.
        """
        trials = 0
        timer.start()
        jitters = []
        while trials < 1000:
            timer.wait()
            # simulate some dag processing time
            time.sleep(0.015)
            jitters.append(timer.jitter_ns)
            trials += 1
        jitters = np.array(jitters)
        max_jitter = np.abs(jitters).max()
>       assert max_jitter < 1e6
E       assert 15807834.0 < 1000000.0
```
Is my `max_cpu_buffer_ns` configurable in a config file?