### PR TITLE
Add markdown link-checker to Github workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Build HTML
           command: |
-            make htmldoc
+            make htmldoc SPHINXOPTS="-b linkcheck"
 
       - store_artifacts:
           path: docs/html/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,20 @@ version: 2.1
 jobs:
   build_docs:
     docker:
-      - image: cimg/base:current-22.04
+      - image: cimg/ruby:3.2.1  # Ruby is needed for html-proofer
     steps:
       - checkout
+
+      # Install html-proofer (to check for broken links) using gem
+      - run:
+          name: Install html-proofer
+          command: gem install html-proofer
+
+      - run:
+          name: Verify Ruby and html-proofer installations
+          command: |
+            ruby --version
+            htmlproofer --version
 
       - run:
           name: Install the latest version of Poetry
@@ -41,6 +52,11 @@ jobs:
           name: Build HTML
           command: |
             make htmldoc SPHINXOPTS="-b linkcheck"
+
+      - run:
+          name: Check for broken links in generated HTML
+          command: |
+            htmlproofer --checks Links,Images docs/html
 
       - store_artifacts:
           path: docs/html/

--- a/.github/allowed_word_list.txt
+++ b/.github/allowed_word_list.txt
@@ -38,6 +38,7 @@ int16
 int8
 jitter
 linalg
+linkcheck
 loadtxt
 lowpass
 lsl

--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -54,7 +54,7 @@ jobs:
         run: poetry run nds_post_install_config
 
       - name: Build HTML
-        run: make htmldoc SPHINXOPTS="-b linkcheck"
+        run: make htmldoc
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -54,7 +54,7 @@ jobs:
         run: poetry run nds_post_install_config
 
       - name: Build HTML
-        run: make htmldoc
+        run: make htmldoc SPHINXOPTS="-b linkcheck"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,7 +76,7 @@ You can do that in one of two ways:
     ```
 
     ```{note}
-       On Windows, if not using the Windows Subsystem for Linux (WSL), you will need to enable `Powershell` to execute scripts via [Set-ExecutionPolicy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.1).
+       On Windows, if not using the Windows Subsystem for Linux (WSL), you will need to enable `Powershell` to execute scripts via [Set-ExecutionPolicy](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.3&viewFallbackFrom=powershell-7.1).
 
        Before executing `poetry shell`, open a `Powershell` window as administrator and run:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -156,6 +156,6 @@ Before opening a pull request, please make sure that all of the following requir
 5. type hinting is used on all function and method parameters and return values, excluding tests
 6. docstring usage conforms to the following:
    1. all docstrings should follow [PEP257 Docstring Conventions](https://peps.python.org/pep-0257/)
-   2. all public API classes, functions, methods, and properties have docstrings and follow the [Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
+   2. all public API classes, functions, methods, and properties have docstrings and follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
    3. docstrings on private objects are not required, but are encouraged where they would significantly aid understanding
 7. testing is done using the pytest library, and test coverage should not unnecessarily decrease.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ release = "0.2.0"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 import os
 import sys
+import re
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "../../src")))
 
@@ -47,6 +48,12 @@ autosummary_generate = True
 templates_path = ["_templates"]
 exclude_patterns = []
 
+# If using linkcheck, ignore relative links in other files that might not yet be
+# generated.
+linkcheck_ignore = [
+    r"^../.*",  # matches links to the parent directory
+    r"^./.*",  # matches links to the same directory
+]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,8 @@ release = "0.2.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 import os
-import sys
 import re
+import sys
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "../../src")))
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -46,7 +46,7 @@ brew install labstreaminglayer/tap/lsl
 On Windows, the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) has to be installed.
 
 ```{note}
-If the command above is not able to find a liblsl package for your system, you can build it manually [following the guide or running the script](https://github.com/sccn/liblsl#building-liblsl).
+If the command above is not able to find a liblsl package for your system, you can build it manually [following the guide or running the script](https://labstreaminglayer.readthedocs.io/dev/lib_dev.html#building-liblsl).
 ```
 
 ## Matplotlib

--- a/examples/plot_run_open_loop.py
+++ b/examples/plot_run_open_loop.py
@@ -12,7 +12,7 @@ needed for training your own decoder.
 By default, this script will download the data to be plotted from AWS S3. If you prefer to use
 your own data, run the following steps:
 
-1. Configure center out reach to `run without a decoder <../utilities_and_examples.html#running-without-a-decoder>`_.
+1. Configure center out reach to `run without a decoder <../tasks.html#running-without-a-decoder>`_.
 
 2. Run the following script::
 

--- a/examples/plot_train_encoder_and_decoder_model.py
+++ b/examples/plot_train_encoder_and_decoder_model.py
@@ -17,8 +17,8 @@ The models will be trained using a slice of data from the dataset
 <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006808>`_,
 specifically the data from `Session 4` with the subject `JenkinsC`.
 
-We mostly followed `decoding arm speed during reaching
-<https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6286377/pdf/41467_2018_Article_7647.pdf>`_
+We mostly followed `Decoding arm speed during reaching
+<https://doi.org/10.1038/s41467-018-07647-3>`_
 for modeling. One reason to follow this paper specifically is that we wanted
 to use a model that incorporated the magnitude of the velocity as well as its
 direction. Traditional cosine tuning curves only include direction.
@@ -151,8 +151,8 @@ np.savez(
 # Create tuning curves
 # --------------------
 # We're ready to start creating the encoder model. We'll follow the
-# equation from `decoding arm speed during reaching
-# <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6286377/pdf/41467_2018_Article_7647.pdf>`_:
+# equation from `Decoding arm speed during reaching
+# <https://doi.org/10.1038/s41467-018-07647-3>`_:
 #
 # :math:`spike rate = b_0 + m * |v| * cos(\theta - \theta_{pd}) + b_s*|v|`
 #


### PR DESCRIPTION
https://github.com/agencyenterprise/neural-data-simulator/issues/29

#### Introduction

To make sure that we don't have any broken links in our repo, we add an action to CI to check for that.

#### Changes

* Check external links during Sphinx-build with `linkcheck` on CI: https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder
* Fix any errors surfaced locally
* Check external/internal links in generated HTML docs with https://github.com/gjtorikian/html-proofer . (https://github.com/stevenvachon/broken-link-checker is no longer maintained)
* Does also switch CircleCI Docker image from `base Ubuntu` to `Ubuntu+Ruby` to more easily install https://github.com/gjtorikian/html-proofer

#### Behavior

* CircleCI docs generation passes here after we have fixed the broken links
* When I was working on this PR and had not fixed all the broken links, it failed (as desired)


Example for `linkcheck` (just checks the Markdown files, not the generated HTML)
Before fixes:
```shell
> make htmldoc SPHINXOPTS="-b linkcheck"
...
(auto_examples/plot_run_open_loop: line   33) -ignored- ../tasks.html#running-without-a-decoder
(auto_examples/plot_train_encoder_and_decoder_model: line   32) ok        https://dandiarchive.org/dandiset/000121
(    contributing: line  109) ok        https://en.wikipedia.org/wiki/Software_versioning#Semantic_versioning
(    contributing: line   65) ok        https://abiword.github.io/enchant/
(    contributing: line  135) ok        https://chocolatey.org/install
(    contributing: line   80) redirect  https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.1 - permanently to https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.3&viewFallbackFrom=powershell-7.1
(auto_examples/plot_train_encoder_and_decoder_model: line  448) ok        https://eval.ai/web/challenges/challenge-page/1256/evaluation
(         encoder: line   49) ok        https://github.com/agencyenterprise/neural-data-simulator/blob/main/src/plugins/examples/model.py
(auto_examples/plot_train_encoder_and_decoder_model: line  448) ok        https://arxiv.org/pdf/2109.04463.pdf
(    installation: line   81) ok        https://github.com/agencyenterprise/neural-data-simulator/issues
(    contributing: line  127) ok        https://github.com/JRubics/poetry-publish
(         encoder: line   37) ok        https://github.com/agencyenterprise/neural-data-simulator/tree/main/src/plugins/examples
(     configuring: line  321) ok        https://github.com/felixpatzelt/colorednoise
(    contributing: line  160) broken    https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings - Anchor '38-comments-and-docstrings' not found
(          inputs: line   19) ok        https://github.com/labstreaminglayer/App-Gamepad/releases
(    contributing: line  111) ok        https://github.com/rymndhng/release-on-push-action/tree/master/
(    contributing: line   63) ok        https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
(    installation: line   54) ok        https://matplotlib.org
(auto_examples/plot_train_encoder_and_decoder_model: line   32) ok        https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006808
(    installation: line   49) broken    https://github.com/sccn/liblsl#building-liblsl - Anchor 'building-liblsl' not found
(     configuring: line  182) ok        https://numpy.org/
(    installation: line   54) ok        https://matplotlib.org/stable/devel/dependencies.html#optional-dependencies
(    contributing: line  126) ok        https://github.com/stefanzweifel/git-auto-commit-action/tree/v4/
(   visualization: line    3) ok        https://open-ephys.github.io/gui-docs/User-Manual/Plugins/LSL-Inlet.html
(    architecture: line   12) ok        https://labstreaminglayer.readthedocs.io/index.html
(   visualization: line    3) ok        https://open-ephys.org/gui
(neural_data_simulator/neural_data_simulator: line   10) ok        https://peps.python.org/pep-0544/
(    contributing: line   30) ok        https://python-poetry.org/docs/#installation
(    contributing: line   69) ok        https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment
(    contributing: line  159) ok        https://peps.python.org/pep-0257/
(    contributing: line   41) ok        https://visualstudio.microsoft.com/visual-cpp-build-tools/
(    contributing: line   65) ok        https://pyenchant.github.io/pyenchant/install.html#installing-the-enchant-c-library
(    contributing: line   28) ok        https://www.python.org/downloads/
(           tasks: line   14) redirect  https://www.pygame.org/ - with Found to https://www.pygame.org/news
(    contributing: line   30) ok        https://python-poetry.org/
(auto_examples/plot_train_encoder_and_decoder_model: line   38) broken    https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6286377/pdf/41467_2018_Article_7647.pdf - 403 Client Error: Forbidden for url: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6286377/pdf/41467_2018_Article_7647.pdf
```
(Note: the linkcheck doesn't like some GitHub anchors, perhaps GitHub is doing something special with the redirects, e.g.: https://github.com/sphinx-doc/sphinx/pull/9467 , so I changed them to point directly to the respective docs)

After fixes:
```shell
> make htmldoc SPHINXOPTS="-b linkcheck"
...
(auto_examples/plot_run_open_loop: line   33) -ignored- ../tasks.html#running-without-a-decoder
(auto_examples/plot_train_encoder_and_decoder_model: line   32) ok        https://dandiarchive.org/dandiset/000121
(    architecture: line   12) ok        https://labstreaminglayer.readthedocs.io/index.html
(    contributing: line  135) ok        https://chocolatey.org/install
(    contributing: line   65) ok        https://abiword.github.io/enchant/
(    contributing: line  109) ok        https://en.wikipedia.org/wiki/Software_versioning#Semantic_versioning
(auto_examples/plot_train_encoder_and_decoder_model: line  448) ok        https://eval.ai/web/challenges/challenge-page/1256/evaluation
(         encoder: line   49) ok        https://github.com/agencyenterprise/neural-data-simulator/blob/main/src/plugins/examples/model.py
(auto_examples/plot_train_encoder_and_decoder_model: line  448) ok        https://arxiv.org/pdf/2109.04463.pdf
(    contributing: line  127) ok        https://github.com/JRubics/poetry-publish
(         encoder: line   37) ok        https://github.com/agencyenterprise/neural-data-simulator/tree/main/src/plugins/examples
(    installation: line   81) ok        https://github.com/agencyenterprise/neural-data-simulator/issues
(          inputs: line   19) ok        https://github.com/labstreaminglayer/App-Gamepad/releases
(    contributing: line  111) ok        https://github.com/rymndhng/release-on-push-action/tree/master/
(     configuring: line  321) ok        https://github.com/felixpatzelt/colorednoise
(auto_examples/plot_train_encoder_and_decoder_model: line   38) redirect  https://doi.org/10.1038/s41467-018-07647-3 - with Found to https://www.nature.com/articles/s41467-018-07647-3
(    contributing: line   63) ok        https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
(    installation: line   49) ok        https://labstreaminglayer.readthedocs.io/dev/lib_dev.html#building-liblsl
(    contributing: line  126) ok        https://github.com/stefanzweifel/git-auto-commit-action/tree/v4/
(    contributing: line  160) ok        https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
(    contributing: line   80) ok        https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.3&amp;viewFallbackFrom=powershell-7.1
(auto_examples/plot_train_encoder_and_decoder_model: line   32) ok        https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006808
(     configuring: line  182) ok        https://numpy.org/
(    installation: line   54) ok        https://matplotlib.org/stable/devel/dependencies.html#optional-dependencies
(   visualization: line    3) ok        https://open-ephys.github.io/gui-docs/User-Manual/Plugins/LSL-Inlet.html
(    contributing: line  159) ok        https://peps.python.org/pep-0257/
(    installation: line   54) ok        https://matplotlib.org
(   visualization: line    3) ok        https://open-ephys.org/gui
(    contributing: line   30) ok        https://python-poetry.org/docs/#installation
(    contributing: line   30) ok        https://python-poetry.org/
(    contributing: line   69) ok        https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment
(    contributing: line   41) ok        https://visualstudio.microsoft.com/visual-cpp-build-tools/
(    contributing: line   65) ok        https://pyenchant.github.io/pyenchant/install.html#installing-the-enchant-c-library
(neural_data_simulator/neural_data_simulator: line   10) ok        https://peps.python.org/pep-0544/
(    contributing: line   28) ok        https://www.python.org/downloads/
(           tasks: line   14) redirect  https://www.pygame.org/ - with Found to https://www.pygame.org/news
```
