### PR TITLE
Make waveforms optional for `Spikes` API

### DIFF
--- a/src/neural_data_simulator/ephys_generator.py
+++ b/src/neural_data_simulator/ephys_generator.py
@@ -158,6 +158,8 @@ class SpikeEvents:
     """The spike waveforms with shape `(n_samples_waveform, n_spike_events)`,
     where `n_samples_waveform` is configurable.
     The values are the amplitudes of the spike waveforms in counts.
+
+    Can be None if only using spike times without waveforms.
     """
 
     class SpikeEvent(NamedTuple):
@@ -170,7 +172,7 @@ class SpikeEvents:
         """The unit that spiked."""
 
         waveform: Optional[ndarray]
-        """The spike waveform."""
+        """The spike waveform. Can be None if only using the spike time."""
 
     def __post_init__(self) -> None:
         """Check that the input data is valid."""

--- a/src/neural_data_simulator/ephys_generator.py
+++ b/src/neural_data_simulator/ephys_generator.py
@@ -792,6 +792,10 @@ class ProcessOutput:
         if self._last_output_time is None:
             raise ValueError("Last output time is not set.")
 
+        assert (
+            spike_events.waveform is not None
+        ), "SpikeEvents.waveform is required to stream continuous data."
+
         if self._outputs.spike_events is not None and len(spike_events) > 0:
             channels = spike_events.unit.reshape(len(spike_events), 1)
             units = np.zeros((len(spike_events), 1))

--- a/src/neural_data_simulator/ephys_generator.py
+++ b/src/neural_data_simulator/ephys_generator.py
@@ -154,7 +154,7 @@ class SpikeEvents:
     first spike event corresponds to the unit 0, the second and the third to the unit 1.
     """
 
-    waveform: ndarray
+    waveform: Optional[ndarray]
     """The spike waveforms with shape `(n_samples_waveform, n_samples)`,
     where `n_samples_waveform` is configurable.
     The values are the amplitudes of the spike waveforms in counts.
@@ -169,7 +169,7 @@ class SpikeEvents:
         unit: int
         """The unit that spiked."""
 
-        waveform: ndarray
+        waveform: Optional[ndarray]
         """The spike waveform."""
 
     def __iter__(self):
@@ -181,10 +181,13 @@ class SpikeEvents:
         """Return the next spike event."""
         if self._current >= len(self.time_idx):
             raise StopIteration
+        waveform = (
+            self.waveform[:, self._current] if (self.waveform is not None) else None
+        )
         result = self.SpikeEvent(
             self.time_idx[self._current],
             self.unit[self._current],
-            self.waveform[:, self._current],
+            waveform,
         )
         self._current += 1
         return result
@@ -195,7 +198,8 @@ class SpikeEvents:
 
     def __getitem__(self, key):
         """Return a subset of the spike events."""
-        return SpikeEvents(self.time_idx[key], self.unit[key], self.waveform[:, key])
+        waveforms = self.waveform[:, key] if (self.waveform is not None) else None
+        return SpikeEvents(self.time_idx[key], self.unit[key], waveforms)
 
 
 class NoiseData:
@@ -382,6 +386,9 @@ class ContinuousData:
     def _spike_events_to_continuous(
         self, spike_events: SpikeEvents, n_samples: int, n_units: int
     ) -> ndarray:
+        assert (
+            spike_events.waveform is not None
+        ), "SpikeEvents.waveform is required to generate continuous data."
         data = np.zeros((n_samples, n_units))
         time_positions = (
             spike_events.time_idx[:, None]
@@ -467,8 +474,8 @@ class Waveforms:
         return unit_waveforms
 
 
-class Spikes:
-    """Spike generator.
+class SpikeTimes:
+    """Spike-time generator without waveforms.
 
     This class generates random spike events according to unit spike rates
     within a given time interval determined by a number of samples and a known
@@ -490,26 +497,23 @@ class Spikes:
         refractory_time: float
         """The refractory time in seconds."""
 
-        n_samples_waveform: int
-        """The number of samples in the spike waveform."""
+        @property
+        def n_refractory_samples(self) -> int:
+            """The number of samples in the refractory period."""
+            return int(self.raw_data_frequency * self.refractory_time)
 
-    def __init__(self, n_channels: int, waveforms: Waveforms, params: Params):
+    def __init__(self, n_channels: int, params: Params):
         """Initialize Spikes class.
 
         Args:
             n_channels: The number of channels. This value together with the configured
                 number of units per channel determines the total number of units
                 for which spikes are generated.
-            waveforms: The :class:`Waveforms` instance with spike waveform prototypes.
             params: The spike generator parameters.
         """
         self._params = params
-        self.waveforms = waveforms
         self.n_units = n_channels * self._params.n_units_per_channel
-
-        self.n_refractory_samples = int(
-            self._params.raw_data_frequency * self._params.refractory_time
-        )
+        self.n_refractory_samples = self._params.n_refractory_samples
 
         self.spikes_buffer = RingBuffer(
             max_samples=int(self._params.raw_data_frequency) * 10,
@@ -599,12 +603,64 @@ class Spikes:
         units, time_idx = self._correct_timeidx(units, time_idx)
 
         self.spikes_buffer.add(spikes[-self.n_refractory_samples :, :])
-        waveforms = self.waveforms.get_spike_waveforms(units)
 
-        return SpikeEvents(time_idx, units, waveforms)
+        return SpikeEvents(time_idx, units, waveform=None)
 
     def _get_spike_chance_for_rate(self, spk_per_sec: ndarray) -> ndarray:
         return spk_per_sec / self._params.raw_data_frequency
+
+
+class Spikes:
+    """Spike generator with waveforms.
+
+    This class generates random spike events according to unit spike rates
+    within a given time interval determined by a number of samples and a known
+    raw data sample rate. It also ensures that the spikes are within the
+    refractory period of each other taking into account the occurrence of the
+    spikes generated in the previous time interval. It applies the corresponding
+    waveforms to each SpikeEvent.
+    """
+
+    class Params(SpikeTimes.Params):
+        """Initialization parameters for the :class:`Spikes` class.
+
+        Alias for :class:`SpikeTimes.Params`.
+        """
+
+        pass
+
+    def __init__(self, n_channels: int, waveforms: Waveforms, params: Params):
+        """Initialize Spikes class.
+
+        Args:
+            n_channels: The number of channels. This value together with the configured
+                number of units per channel determines the total number of units
+                for which spikes are generated.
+            waveforms: The :class:`Waveforms` instance with spike waveform prototypes.
+            params: The :class:`SpikeTimes` generator parameters.
+        """
+        self.spike_times = SpikeTimes(n_channels, params=params)
+        self.waveforms = waveforms
+
+    def generate_spikes(self, rates: ndarray, n_samples: int) -> SpikeEvents:
+        """Generate spikes for the given rates and a given number of samples.
+
+        Calls into the :meth:`SpikeTimes.generate_spikes` method, then applies
+        the waveforms.
+
+        Args:
+            rates: The spike rates array with shape (n_units,).
+                Each element in the array represents the spike rate in spikes
+                per second for the corresponding unit.
+            n_samples: The number of samples to output.
+
+        Returns:
+            The generated spikes as :class:`SpikeEvents`.
+        """
+        spike_events: SpikeEvents = self.spike_times.generate_spikes(rates, n_samples)
+        spike_events.waveform = self.waveforms.get_spike_waveforms(spike_events.unit)
+
+        return spike_events
 
 
 class ProcessOutput:

--- a/src/neural_data_simulator/scripts/run_ephys_generator.py
+++ b/src/neural_data_simulator/scripts/run_ephys_generator.py
@@ -123,7 +123,6 @@ def _get_spikes_params(
         ephys_generator_settings.raw_data_frequency,
         ephys_generator_settings.n_units_per_channel,
         ephys_generator_settings.refractory_time,
-        ephys_generator_settings.waveforms.n_samples,
     )
 
 

--- a/tests/scripts/test_run_ephys_generator.py
+++ b/tests/scripts/test_run_ephys_generator.py
@@ -96,11 +96,10 @@ class TestRunEphysGenerator:
             lfp_filter_cutoff=300.0,
             lfp_filter_order=4,
         )
-        assert po_init.args[1]._params == Spikes.Params(
+        assert po_init.args[1].spike_times._params == Spikes.Params(
             raw_data_frequency=30000.0,
             n_units_per_channel=1,
             refractory_time=0.001,
-            n_samples_waveform=48,
         )
         assert po_start == call().start()
         assert po_stop == call().stop()


### PR DESCRIPTION
https://github.com/agencyenterprise/neural-data-simulator/issues/30

#### Introduction

User feedback: 

> I had a use case where I used the `Spikes` class to generate fake spikes so I could check the statistics of the fake vs real spikes.  I didn’t need `waveforms` so factoring `Spikes` into something that doesn’t depend on waveforms (or only optionally does)... would be great.

This is a common use-case: the user may not want to use the compute-power to simulate full-bandwidth ephys signals and may only be interested in the spike times.

#### Changes

* Decompose `Spikes` class into a `SpikeTimes`-generator class (no waveforms) and a `Waveforms`-loading class (already defined)
* Updated `pytest` tests as needed

#### Behavior

* Works the same, based on `pytest` and running `run_closed_loop` locally/
* Developers can now instantiate a `SpikeTimes` generator class without defining `Waveforms`
