### PR TITLE
Index colors modulo the color-list-length

### DIFF
--- a/src/tasks/center_out_reach/metrics.py
+++ b/src/tasks/center_out_reach/metrics.py
@@ -203,16 +203,17 @@ class MetricsCollector:
         cursor = 0
         for trial_count in np.unique(trial_counts):
             end_of_task = np.where(trial_counts == trial_count)[0][-1]
+            color = colors[trial_count % len(colors)]
             plt.plot(
                 decoded_positions[cursor:end_of_task, 0],
                 decoded_positions[cursor:end_of_task, 1],
-                colors[trial_count],
+                color=color,
                 alpha=0.6,
             )
             plt.plot(
                 actual_positions[cursor:end_of_task, 0],
                 actual_positions[cursor:end_of_task, 1],
-                colors[trial_count],
+                color=color,
                 linestyle="--",
                 alpha=0.6,
             )


### PR DESCRIPTION
#### Introduction

Steps to reproduce previous bug:
* accidentally leave the center-out-task running for 2 hours while having dinner
* come back to laptop to realize that center-out task is still running
* press `Esc` to finish the center-out task

```
INFO [nds-run-closed-loop]: Terminating decoder
INFO [nds-run-closed-loop]: Waiting for center_out_reach
Traceback (most recent call last):
  File "/Users/charles/mambaforge/envs/nds/bin/center_out_reach", line 6, in <module>
    sys.exit(run())
             ^^^^^
  File "/Users/charles/Development/nds/src/tasks/run_center_out_reach.py", line 390, in run
    unwrap(metrics_collector).plot_metrics(task_window.target_positions)
  File "/Users/charles/Development/nds/src/tasks/center_out_reach/metrics.py", line 290, in plot_metrics
    self._plot_positions(targets)
  File "/Users/charles/Development/nds/src/tasks/center_out_reach/metrics.py", line 208, in _plot_positions
    colors[trial_count],
    ~~~~~~^^^^^^^^^^^^^
IndexError: list index out of range
INFO [nds-run-closed-loop]: Done
(nds)
```

#### Changes

* Index the colors-list (which, to be fair, is quite long already) modulo the length
```python
>>> len(mcolors.XKCD_COLORS)
949
```

#### Behavior
* Leave the `center_out_task` running for 6 seconds * 949 trials ~= 100 minutes, then finish. Task  finishes gracefully.

<img width="617" alt="image" src="https://github.com/agencyenterprise/neural-data-simulator/assets/3221512/f0f49dcd-b48b-49cd-8e45-7839c7994822">
