### PR TITLE
Run closed loop with remote task

### DIFF
--- a/src/neural_data_simulator/tasks/run_closed_loop.py
+++ b/src/neural_data_simulator/tasks/run_closed_loop.py
@@ -84,9 +84,9 @@ def _parse_args():
     )
 
     parser.add_argument(
-        "--headless",
+        "--remote-task",
         action="store_true",
-        help="Run in headless mode without starting the center_out_reach task.",
+        help="Run without the center_out_reach task, expecting a remote task to be used.",
     )
 
     args = parser.parse_args()
@@ -167,8 +167,8 @@ def run():
     ephys = _run_process(["ephys_generator"] + nds_params)
     decoder = _run_process(["decoder"] + decoder_params)
 
-    if args.headless:
-        logger.info("Running in headless mode. Press CTRL+C to stop.")
+    if args.remote_task:
+        logger.info("Running with remote task. Press CTRL+C to exit.")
         try:
             while True:
                 time.sleep(1)

--- a/src/neural_data_simulator/tasks/run_closed_loop.py
+++ b/src/neural_data_simulator/tasks/run_closed_loop.py
@@ -86,7 +86,7 @@ def _parse_args():
     parser.add_argument(
         "--remote-task",
         action="store_true",
-        help="Run without the center_out_reach task, expecting a remote task to be used.",
+        help="Run without center_out_reach task, expecting a remote task to be used.",
     )
 
     args = parser.parse_args()

--- a/src/neural_data_simulator/tasks/run_closed_loop.py
+++ b/src/neural_data_simulator/tasks/run_closed_loop.py
@@ -82,6 +82,13 @@ def _parse_args():
             "For example: -to log_level=DEBUG center_out_reach.task.target_radius=0.03"
         ),
     )
+
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run in headless mode without starting the center_out_reach task.",
+    )
+
     args = parser.parse_args()
 
     return args
@@ -160,27 +167,37 @@ def run():
     ephys = _run_process(["ephys_generator"] + nds_params)
     decoder = _run_process(["decoder"] + decoder_params)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        control_file_path = os.path.join(temp_dir, "center_out_reach_control_file")
-        Path(control_file_path).touch(exist_ok=False)
-        center_out_reach = _run_process(
-            ["center_out_reach", "--control-file", control_file_path] + task_params
-        )
-        logger.info("Modules started")
-
+    if args.headless:
+        logger.info("Running in headless mode. Press CTRL+C to stop.")
         try:
-            _wait_for_center_out_reach_main_task(control_file_path, center_out_reach)
+            while True:
+                time.sleep(1)
         except KeyboardInterrupt:
             logger.info("CTRL+C received. Exiting...")
-            _terminate_process("center_out_reach", center_out_reach)
+    else:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            control_file_path = os.path.join(temp_dir, "center_out_reach_control_file")
+            Path(control_file_path).touch(exist_ok=False)
+            center_out_reach = _run_process(
+                ["center_out_reach", "--control-file", control_file_path] + task_params
+            )
+            logger.info("Modules started")
 
-        _terminate_process("encoder", encoder)
-        _terminate_process("ephys_generator", ephys)
-        _terminate_process("decoder", decoder)
+            try:
+                _wait_for_center_out_reach_main_task(
+                    control_file_path, center_out_reach
+                )
+            except KeyboardInterrupt:
+                logger.info("CTRL+C received. Exiting...")
+                _terminate_process("center_out_reach", center_out_reach)
 
-        if center_out_reach.poll() is None:
-            logger.info("Waiting for center_out_reach")
-            center_out_reach.wait()
+            if center_out_reach.poll() is None:
+                logger.info("Waiting for center_out_reach")
+                center_out_reach.wait()
+
+    _terminate_process("encoder", encoder)
+    _terminate_process("ephys_generator", ephys)
+    _terminate_process("decoder", decoder)
 
     logger.info("Done")
 


### PR DESCRIPTION
#### Introduction

Adding a new command like argument to `run_closed_loop` in order to support a remote task. This means that the local center_out_reach task will not be started and the `encoder` will wait for a remote LSL stream to become available.
