### PR TITLE
Fixed typo in encoder documentation

### DIFF
--- a/docs/source/encoder.md
+++ b/docs/source/encoder.md
@@ -73,7 +73,7 @@ The following snippet is a minimal but complete example of a preprocessor that j
 ```
 """An example preprocessor"""
 from neural_data_simulator.core.encoder import Processor
-from neural_data_simulator.samples import Samples
+from neural_data_simulator.core.samples import Samples
 
 
 class PassThroughPreprocessor(Processor):


### PR DESCRIPTION
Fixed typo in encoder documentation.

Line 76 in docs/source/encoder.md was:
from neural_data_simulator.samples import Samples

Suggested change:
from neural_data_simulator**.core**.samples import Samples
